### PR TITLE
Countdown timer before scrolling (#9)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,8 @@
 import {
   createState,
   toggleScrolling,
+  startCountdown,
+  countdownText,
   tick as tickState,
   visibleText,
   annotatedLines,
@@ -23,20 +25,38 @@ const scriptEl = document.getElementById("script-text")!;
 const statusEl = document.getElementById("status")!;
 
 function renderBrowser() {
-  scriptEl.innerHTML = "";
-  for (const line of annotatedLines(state)) {
+  const cdText = countdownText(state);
+  if (cdText) {
+    scriptEl.innerHTML = "";
     const div = document.createElement("div");
-    div.textContent = line.text || "\u00A0"; // non-breaking space for empty lines
-    div.style.color = line.isCurrent ? "#fff" : "#888";
+    div.textContent = cdText;
+    div.style.color = "#fff";
+    div.style.fontSize = "48px";
+    div.style.textAlign = "center";
     scriptEl.appendChild(div);
+    statusEl.textContent = "⏳";
+  } else {
+    scriptEl.innerHTML = "";
+    for (const line of annotatedLines(state)) {
+      const div = document.createElement("div");
+      div.textContent = line.text || "\u00A0";
+      div.style.color = line.isCurrent ? "#fff" : "#888";
+      scriptEl.appendChild(div);
+    }
+    statusEl.textContent = state.scrolling ? `▶ ${state.speedWpm} WPM` : "⏸";
   }
-  statusEl.textContent = state.scrolling ? `▶ ${state.speedWpm} WPM` : "⏸";
 }
 
 document.addEventListener("keydown", (e) => {
   if (e.code === "Space") {
     e.preventDefault();
-    state = toggleScrolling(state);
+    if (state.countdown > 0) {
+      state = toggleScrolling(state);
+    } else if (state.scrolling) {
+      state = toggleScrolling(state);
+    } else {
+      state = startCountdown(state);
+    }
   }
   if (e.code === "KeyR") {
     state = restart(state);

--- a/src/teleprompter.ts
+++ b/src/teleprompter.ts
@@ -26,6 +26,8 @@ export interface TeleprompterState {
   lineIndex: number;
   /** Fractional accumulator for sub-line ticks. */
   _lineFrac: number;
+  /** Seconds remaining in countdown (0 means no countdown active). */
+  countdown: number;
 }
 
 /**
@@ -63,10 +65,14 @@ export function createState(text: string = SAMPLE_TEXT): TeleprompterState {
     speedWpm: 150,
     lineIndex: 0,
     _lineFrac: 0,
+    countdown: 0,
   };
 }
 
 export function toggleScrolling(state: TeleprompterState): TeleprompterState {
+  if (state.countdown > 0) {
+    return { ...state, countdown: 0, scrolling: false };
+  }
   return { ...state, scrolling: !state.scrolling };
 }
 
@@ -75,7 +81,16 @@ export function setSpeed(state: TeleprompterState, wpm: number): TeleprompterSta
 }
 
 export function restart(state: TeleprompterState): TeleprompterState {
-  return { ...state, lineIndex: 0, _lineFrac: 0, scrolling: false };
+  return { ...state, lineIndex: 0, _lineFrac: 0, scrolling: false, countdown: 0 };
+}
+
+export function startCountdown(state: TeleprompterState, seconds: number = 3): TeleprompterState {
+  return { ...state, countdown: seconds, scrolling: false };
+}
+
+export function countdownText(state: TeleprompterState): string | null {
+  if (state.countdown <= 0) return null;
+  return String(Math.ceil(state.countdown));
 }
 
 /**
@@ -92,6 +107,13 @@ export function linesPerTick(speedWpm: number): number {
  * fractional ticks have accumulated.
  */
 export function tick(state: TeleprompterState): TeleprompterState {
+  if (state.countdown > 0) {
+    const newCountdown = state.countdown - 1 / 60;
+    if (newCountdown <= 0) {
+      return { ...state, countdown: 0, scrolling: true };
+    }
+    return { ...state, countdown: newCountdown };
+  }
   if (!state.scrolling) return state;
   const maxLine = state.lines.length - 1;
   if (state.lineIndex >= maxLine) return { ...state, scrolling: false };

--- a/tests/teleprompter.test.ts
+++ b/tests/teleprompter.test.ts
@@ -14,6 +14,8 @@ import {
   isFinished,
   wrapText,
   annotatedLines,
+  startCountdown,
+  countdownText,
 } from "../src/teleprompter";
 import type { AnnotatedLine } from "../src/teleprompter";
 
@@ -58,6 +60,10 @@ describe("createState", () => {
   it("starts at line 0", () => {
     expect(createState().lineIndex).toBe(0);
   });
+
+  it("starts with countdown at 0", () => {
+    expect(createState().countdown).toBe(0);
+  });
 });
 
 describe("toggleScrolling", () => {
@@ -67,6 +73,13 @@ describe("toggleScrolling", () => {
 
   it("toggles back to paused", () => {
     expect(toggleScrolling(toggleScrolling(createState())).scrolling).toBe(false);
+  });
+
+  it("cancels countdown when countdown > 0 (scrolling stays false)", () => {
+    const state = { ...createState("Hello"), countdown: 2 };
+    const result = toggleScrolling(state);
+    expect(result.countdown).toBe(0);
+    expect(result.scrolling).toBe(false);
   });
 });
 
@@ -100,6 +113,26 @@ describe("tick", () => {
     let state = toggleScrolling(createState(SAMPLE_TEXT));
     for (let i = 0; i < 10000; i++) state = tick(state);
     expect(state.lineIndex).toBeGreaterThan(0);
+  });
+
+  it("decrements countdown when countdown > 0", () => {
+    const state = { ...createState("Hello"), countdown: 3 };
+    const result = tick(state);
+    expect(result.countdown).toBeCloseTo(3 - 1 / 60, 10);
+  });
+
+  it("does not scroll while countdown is active", () => {
+    const state = { ...createState("Hello"), countdown: 3 };
+    const result = tick(state);
+    expect(result.lineIndex).toBe(0);
+    expect(result.scrolling).toBe(false);
+  });
+
+  it("starts scrolling when countdown crosses 0", () => {
+    const state = { ...createState("Hello"), countdown: 1 / 120 };
+    const result = tick(state);
+    expect(result.countdown).toBe(0);
+    expect(result.scrolling).toBe(true);
   });
 
   it("does not exceed last line", () => {
@@ -157,6 +190,48 @@ describe("restart", () => {
   it("pauses scrolling", () => {
     const state = { ...createState(SAMPLE_TEXT), scrolling: true };
     expect(restart(state).scrolling).toBe(false);
+  });
+
+  it("resets countdown", () => {
+    const state = { ...createState(SAMPLE_TEXT), countdown: 2 };
+    expect(restart(state).countdown).toBe(0);
+  });
+});
+
+describe("startCountdown", () => {
+  it("sets countdown to given seconds", () => {
+    expect(startCountdown(createState("Hello"), 3).countdown).toBe(3);
+  });
+
+  it("defaults to 3 seconds", () => {
+    expect(startCountdown(createState("Hello")).countdown).toBe(3);
+  });
+
+  it("sets scrolling to false", () => {
+    const state = { ...createState("Hello"), scrolling: true };
+    expect(startCountdown(state, 3).scrolling).toBe(false);
+  });
+});
+
+describe("countdownText", () => {
+  it("returns null when countdown is 0", () => {
+    expect(countdownText(createState("Hello"))).toBeNull();
+  });
+
+  it("returns '3' when countdown is between 2 and 3", () => {
+    expect(countdownText({ ...createState("Hello"), countdown: 2.5 })).toBe("3");
+  });
+
+  it("returns '2' when countdown is between 1 and 2", () => {
+    expect(countdownText({ ...createState("Hello"), countdown: 1.5 })).toBe("2");
+  });
+
+  it("returns '1' when countdown is between 0 and 1", () => {
+    expect(countdownText({ ...createState("Hello"), countdown: 0.5 })).toBe("1");
+  });
+
+  it("returns '3' when countdown is exactly 3", () => {
+    expect(countdownText({ ...createState("Hello"), countdown: 3 })).toBe("3");
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `countdown` field to state, `startCountdown()`, `countdownText()` functions
- `tick()` decrements countdown at 60fps; starts scrolling when it hits 0
- `toggleScrolling()` cancels active countdown
- Space key: start countdown → cancel countdown → pause scrolling
- Countdown number displayed in browser UI when active

Closes #9

## Test plan
- [x] 14 new tests covering countdown start, text display, tick decrement/transition, cancel behavior
- [x] All 46 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)