### PR TITLE
Load script from URL or clipboard (#11)

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,0 +1,18 @@
+/**
+ * Script loading utilities — parse URL params and validate URLs.
+ */
+
+export function parseScriptUrl(search: string): string | null {
+  const params = new URLSearchParams(search);
+  const url = params.get("script");
+  return url || null;
+}
+
+export function isValidUrl(str: string): boolean {
+  try {
+    const url = new URL(str);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import {
   DISPLAY_WIDTH,
   DISPLAY_HEIGHT,
 } from "./teleprompter";
+import { parseScriptUrl, isValidUrl } from "./loader";
 import {
   STORAGE_KEY,
   DEFAULT_SETTINGS,
@@ -49,6 +50,32 @@ function saveSettings(settings: Settings): void {
 
 const initialSettings = loadSettings();
 let state = setSpeed(toggleScrolling(createState(SAMPLE_TEXT)), initialSettings.speedWpm);
+
+// --- Load script from URL param ---
+async function loadScriptFromUrl() {
+  const url = parseScriptUrl(window.location.search);
+  if (url && isValidUrl(url)) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        const text = await response.text();
+        state = setSpeed(toggleScrolling(createState(text)), state.speedWpm);
+      }
+    } catch {
+      // Fetch failed — keep default script
+    }
+  }
+}
+
+loadScriptFromUrl();
+
+// --- Paste handler ---
+document.addEventListener("paste", (e) => {
+  const text = e.clipboardData?.getData("text/plain");
+  if (text) {
+    state = setSpeed(createState(text), state.speedWpm);
+  }
+});
 
 // --- Browser fallback UI ---
 const scriptEl = document.getElementById("script-text")!;

--- a/tests/loader.test.ts
+++ b/tests/loader.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { parseScriptUrl, isValidUrl } from "../src/loader";
+
+describe("parseScriptUrl", () => {
+  it("extracts script URL from query string", () => {
+    expect(parseScriptUrl("?script=https://example.com/speech.txt")).toBe("https://example.com/speech.txt");
+  });
+
+  it("returns null when no script param", () => {
+    expect(parseScriptUrl("?other=value")).toBeNull();
+  });
+
+  it("returns null for empty query string", () => {
+    expect(parseScriptUrl("")).toBeNull();
+  });
+
+  it("returns null when script param is empty", () => {
+    expect(parseScriptUrl("?script=")).toBeNull();
+  });
+
+  it("handles encoded URLs", () => {
+    expect(parseScriptUrl("?script=https%3A%2F%2Fexample.com%2Ftest.txt")).toBe("https://example.com/test.txt");
+  });
+});
+
+describe("isValidUrl", () => {
+  it("accepts https URLs", () => {
+    expect(isValidUrl("https://example.com/file.txt")).toBe(true);
+  });
+
+  it("accepts http URLs", () => {
+    expect(isValidUrl("http://example.com/file.txt")).toBe(true);
+  });
+
+  it("rejects non-http protocols", () => {
+    expect(isValidUrl("ftp://example.com")).toBe(false);
+  });
+
+  it("rejects plain text", () => {
+    expect(isValidUrl("not a url")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidUrl("")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/loader.ts` with `parseScriptUrl()` and `isValidUrl()` pure functions
- On startup, checks `?script=URL` query param and fetches remote script
- Paste event replaces current script with clipboard text
- Falls back to SAMPLE_TEXT on fetch failure or no source

Closes #11

## Test plan
- [x] 10 new tests in `tests/loader.test.ts` covering URL parsing, validation, edge cases
- [x] All 66 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)