### PR TITLE
Fix LVGL glyph warning on glasses speed change

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -144,8 +144,8 @@ function glassesStatusText(): string {
   const elapsed = formatTime(elapsedSeconds(state));
   const remaining = formatTime(remainingSeconds(state));
   return state.scrolling
-    ? `▶ ${state.speedWpm} WPM | ${elapsed} / -${remaining}`
-    : `⏸ ${state.speedWpm} WPM | ${elapsed} / -${remaining}`;
+    ? `> ${state.speedWpm} WPM | ${elapsed} / -${remaining}`
+    : `|| ${state.speedWpm} WPM | ${elapsed} / -${remaining}`;
 }
 
 function glassesContent(): string {


### PR DESCRIPTION
## Summary
LVGL on the glasses lacks glyphs for `▶` (U+25B6) and `⏸` (U+23F8), causing warnings when adjusting speed with up/down. Replace with ASCII `>` and `||` in the glasses status text. Browser UI keeps the emoji.

## Test plan
- [x] All 100 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)