### PR TITLE
Add CLAUDE.md, architecture docs, and user guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# Teleprompter — Claude Code Guide
+
+## Project Overview
+
+A teleprompter app for Even Realities G1/G2 smart glasses, built with TypeScript, Vite, and the Even Hub SDK. Runs in the browser as a simulator and deploys to glasses via the Even Hub platform.
+
+## Tech Stack
+
+- **TypeScript** + **Vite** — dev server and build
+- **@evenrealities/even_hub_sdk** — glasses communication
+- **Vitest** — test runner
+- **Even Hub CLI** — packaging and deployment
+
+## Architecture
+
+Pure-function core (`src/teleprompter.ts`) with no side effects. UI layer (`src/main.ts`) connects core to browser DOM and Even Hub bridge. Supporting modules are each a single-file pure-function library with its own test file.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/teleprompter.ts` | Core state machine — all pure functions |
+| `src/main.ts` | Entry point — browser UI + glasses bridge |
+| `src/storage.ts` | Settings persistence (localStorage) |
+| `src/loader.ts` | Script loading from URL params |
+| `src/gestures.ts` | Glasses gesture → action mapping |
+| `src/connection.ts` | Glasses connection status tracking |
+| `src/markdown.ts` | Markdown parsing (bold, italic, headings) |
+| `src/settings-url.ts` | Settings URL encoding/decoding for sharing |
+
+## Development Workflow
+
+**Strict TDD** (ADR 0003): write failing test → implement → commit → refactor → commit → repeat.
+
+**All changes via PR.** Branch protection requires 1 approval + passing CI.
+
+## Commands
+
+```bash
+npm install        # install deps
+npm run dev        # browser simulator at localhost:5173
+npm test           # run vitest
+npm run build      # production build
+```
+
+## Testing
+
+163+ tests across 9 test files. Each `src/*.ts` module has a corresponding `tests/*.test.ts`. Run `npm test` before every commit.
+
+## Conventions
+
+- Pure functions in `src/teleprompter.ts` — no side effects, no DOM, no SDK
+- State is immutable — functions return new state objects
+- `_` prefix on internal state fields (`_lineFrac`, `_wordCount`)
+- ASCII-only in glasses text (LVGL has limited glyph support)
+- Browser UI can use Unicode emoji; glasses text cannot

--- a/README.md
+++ b/README.md
@@ -1,34 +1,64 @@
 # Teleprompter
 
-A teleprompter app for [Even Realities](https://evenrealities.com/) smart glasses, built with TypeScript and the Even Hub SDK.
+A teleprompter app for [Even Realities](https://evenrealities.com/) smart glasses, built with TypeScript and the [Even Hub SDK](https://hub.evenrealities.com/).
 
-## Setup
+```mermaid
+graph LR
+    SCRIPT[Your Script] --> APP[Teleprompter App]
+    APP --> BROWSER[Browser Simulator]
+    APP --> GLASSES[Even Realities Glasses]
+```
+
+## Quick Start
 
 ```bash
 npm install
-```
-
-## Run (browser simulator)
-
-```bash
 npm run dev
 ```
 
-Open http://localhost:5173 — press **Space** to start/stop scrolling.
+Open http://localhost:5173 — press **Space** to start scrolling.
+
+## Controls
+
+| Key | Action |
+|-----|--------|
+| **Space** | Start / Pause / Resume |
+| **R** | Restart |
+| **Up/Down** | Adjust speed |
+| **S** | Copy share URL |
+| **Double-click** | Restart |
+
+On glasses: **tap** to pause/resume, **double-tap** to restart.
+
+## Load a Script
+
+```
+http://localhost:5173/?script=https://example.com/speech.txt
+```
+
+Or paste from clipboard (**Ctrl+V**).
 
 ## Test
 
 ```bash
-npm test
+npm test           # 163+ tests
 ```
 
-## Deploy to glasses
+## Deploy to Glasses
 
 ```bash
 npm run build
 npx @evenrealities/evenhub-cli pack app.json ./dist
 ```
 
+## Documentation
+
+- [User Guide](docs/user-guide.md) — controls, loading scripts, sharing settings
+- [Architecture](docs/architecture.md) — system design, state machine, module map
+- [ADRs](docs/adr/) — architectural decision records
+
 ## Development
 
-We follow strict TDD (see [ADR 0003](docs/adr/0003-tdd-workflow.md)). All changes require a PR with passing tests and at least one approval.
+We follow strict TDD ([ADR 0003](docs/adr/0003-tdd-workflow.md)). All changes require a PR with passing tests and at least one approval.
+
+See [CLAUDE.md](CLAUDE.md) for Claude Code development conventions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,166 @@
+# Architecture
+
+## System Overview
+
+```mermaid
+graph TB
+    subgraph Browser["Browser Simulator"]
+        HTML[index.html]
+        DOM[DOM Renderer]
+        KB[Keyboard Events]
+    end
+
+    subgraph Core["Pure Logic Layer"]
+        TP[teleprompter.ts<br/>State Machine]
+        ST[storage.ts<br/>Settings]
+        LD[loader.ts<br/>URL Loader]
+        GE[gestures.ts<br/>Gesture Mapping]
+        CN[connection.ts<br/>Connection Status]
+        MD[markdown.ts<br/>Markdown Parser]
+        SU[settings-url.ts<br/>URL Sharing]
+    end
+
+    subgraph Glasses["Even Realities Glasses"]
+        SDK[Even Hub SDK]
+        BLE[BLE Bridge]
+        DISP[Glasses Display<br/>576x288]
+    end
+
+    MAIN[main.ts<br/>Entry Point]
+
+    KB --> MAIN
+    MAIN --> TP
+    MAIN --> DOM
+    MAIN --> SDK
+    SDK --> BLE --> DISP
+    MAIN --> ST
+    MAIN --> LD
+    MAIN --> GE
+    MAIN --> CN
+    MAIN --> SU
+```
+
+## State Machine
+
+The core of the app is a pure state machine in `teleprompter.ts`. All state transitions are pure functions that take the current state and return a new state.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Paused: createState()
+    Paused --> Countdown: startCountdown()
+    Countdown --> Scrolling: countdown reaches 0
+    Countdown --> Paused: toggleScrolling() cancels
+    Scrolling --> Paused: toggleScrolling()
+    Scrolling --> Finished: last line reached
+    Paused --> Paused: restart()
+    Scrolling --> Paused: restart()
+    Finished --> Paused: restart()
+    Countdown --> Paused: restart()
+```
+
+## State Shape
+
+```mermaid
+classDiagram
+    class TeleprompterState {
+        +string[] lines
+        +boolean scrolling
+        +number speedWpm
+        +number lineIndex
+        +number _lineFrac
+        +number elapsedTicks
+        +number countdown
+        +number _wordCount
+    }
+
+    class AnnotatedLine {
+        +string text
+        +boolean isCurrent
+    }
+
+    TeleprompterState --> AnnotatedLine : annotatedLines()
+```
+
+## Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Input
+        SPACE[Space Key]
+        ARROWS[Arrow Keys]
+        TAP[Glasses Tap]
+        PASTE[Paste Event]
+        URL[URL Params]
+    end
+
+    subgraph Processing
+        STATE[TeleprompterState]
+        TICK[tick @ 60fps]
+    end
+
+    subgraph Output
+        BDOM[Browser DOM<br/>7 visible lines]
+        GLASS[Glasses Text<br/>Container @ 500ms]
+        STATUS[Status Bar<br/>WPM / Time]
+        LSTOR[localStorage]
+    end
+
+    SPACE --> STATE
+    ARROWS --> STATE
+    TAP --> STATE
+    PASTE --> STATE
+    URL --> STATE
+    TICK --> STATE
+    STATE --> BDOM
+    STATE --> GLASS
+    STATE --> STATUS
+    STATE --> LSTOR
+```
+
+## Module Dependencies
+
+```mermaid
+graph LR
+    main --> teleprompter
+    main --> storage
+    main --> loader
+    main --> gestures
+    main --> connection
+    main --> settings-url
+    main --> even_hub_sdk
+
+    style teleprompter fill:#2d5,stroke:#fff,color:#fff
+    style main fill:#d52,stroke:#fff,color:#fff
+    style even_hub_sdk fill:#25d,stroke:#fff,color:#fff
+```
+
+Green = pure logic (no side effects), Red = entry point (side effects), Blue = external SDK.
+
+## Rendering Pipeline
+
+### Browser (60fps)
+
+1. `tick(state)` advances state
+2. If state changed (reference check), `renderBrowser()` runs:
+   - Clear `#script-text` innerHTML
+   - Create `<div>` per visible line (7 lines)
+   - Apply highlight to current line (white, larger, left border)
+   - Apply `translateY` for smooth sub-pixel scrolling via `_lineFrac`
+   - Update status bar text
+
+### Glasses (500ms interval)
+
+1. Build `glassesContent()` = script text + status line
+2. Skip if content string unchanged since last push
+3. Send via `bridge.textContainerUpgrade()`
+
+## Display Constraints
+
+| Property | Value |
+|----------|-------|
+| Canvas width | 576px |
+| Canvas height | 288px |
+| Max text per container | 2000 chars |
+| Max containers per page | 4 |
+| Text encoding | ASCII only (LVGL limitation) |
+| Line width | 40 chars (CHARS_PER_LINE) |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,123 @@
+# User Guide
+
+## Getting Started
+
+### Browser Simulator
+
+```bash
+npm install
+npm run dev
+```
+
+Open http://localhost:5173 to see the glasses simulator.
+
+### Even Realities Glasses
+
+Use the [even-dev simulator](https://github.com/BxNxM/even-dev) for testing:
+
+```bash
+git clone https://github.com/BxNxM/even-dev.git
+cd even-dev && npm install
+APP_PATH=../teleprompter ./start-even.sh
+```
+
+Or deploy to real glasses:
+
+```bash
+npm run build
+npx @evenrealities/evenhub-cli pack app.json ./dist
+```
+
+## Controls
+
+### Browser Keyboard
+
+| Key | Action |
+|-----|--------|
+| **Space** | Start countdown / Pause / Resume |
+| **R** | Restart from beginning |
+| **Up Arrow** | Speed up (+10 WPM) |
+| **Down Arrow** | Slow down (-10 WPM) |
+| **S** | Copy share URL to clipboard |
+| **Double-click** | Restart from beginning |
+| **Ctrl+V** | Load script from clipboard |
+
+### Glasses Gestures
+
+| Gesture | Action |
+|---------|--------|
+| **Single tap** | Pause / Resume |
+| **Double tap** | Restart from beginning |
+| **Swipe (list index 0)** | Speed up |
+| **Swipe (list index 1)** | Slow down |
+
+## Loading Scripts
+
+### From URL
+
+Add `?script=` to load a remote text file:
+
+```
+http://localhost:5173/?script=https://example.com/my-speech.txt
+```
+
+### From Clipboard
+
+1. Copy your script text
+2. Click the simulator window
+3. Press **Ctrl+V** (or **Cmd+V** on Mac)
+
+### Default Script
+
+If no script is provided, the Gettysburg Address is displayed.
+
+## Sharing Settings
+
+Press **S** to copy a URL with your current speed setting to the clipboard:
+
+```
+http://localhost:5173/?speed=180
+```
+
+Combine with a script URL:
+
+```
+http://localhost:5173/?speed=180&script=https://example.com/speech.txt
+```
+
+## Display
+
+```mermaid
+graph TB
+    subgraph Glasses["Glasses Display (576x288)"]
+        L1["<b>Current line highlighted</b>"]
+        L2[Dimmed upcoming lines...]
+        L3[...]
+        STATUS["> 150 WPM | 01:05 / -02:30 | Glasses connected"]
+    end
+```
+
+### Status Bar
+
+When scrolling:
+```
+> 150 WPM | 01:05 / -02:30 | Browser only
+```
+
+When paused:
+```
+|| 271 words | ~01:48 | Browser only
+```
+
+- **WPM** — current scroll speed
+- **Elapsed / Remaining** — time tracking
+- **Word count / Read time** — shown when paused
+- **Connection** — glasses status
+
+## Countdown
+
+When you press **Space** to start, a 3-second countdown (3... 2... 1...) appears before scrolling begins. Press **Space** again during the countdown to cancel.
+
+## Persistence
+
+Your speed setting is automatically saved to localStorage and restored on next visit. On glasses, settings sync via the Even Hub bridge storage.


### PR DESCRIPTION
## Summary
- **CLAUDE.md** — project conventions, key files, commands, testing approach
- **docs/architecture.md** — system overview, state machine, data flow, module dependencies, rendering pipeline, display constraints (6 Mermaid diagrams)
- **docs/user-guide.md** — controls, loading scripts, sharing settings, display layout, countdown, persistence
- **README.md** — updated with quick reference table and links to all docs

## Test plan
- [x] All 163 tests passing (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)